### PR TITLE
質問の回答のテキストが正常に表示されないバグを修正

### DIFF
--- a/src/app/api/gpt.ts
+++ b/src/app/api/gpt.ts
@@ -106,7 +106,10 @@ export const askQuestion = async (
 
   try {
     for await (const chunk of stream) {
-      onStreamChunk(chunk.choices[0].delta.content ?? "");
+      const content = chunk.choices[0].delta.content;
+      if (content !== "") {
+        onStreamChunk(content ?? "");
+      }
     }
 
     onStreamEnd();

--- a/src/app/api/gpt/question/route.ts
+++ b/src/app/api/gpt/question/route.ts
@@ -8,9 +8,16 @@ export async function POST(req: Request) {
   askQuestion(
     body.messages,
     (message) => {
-      writer.write(`data: ${message}\n\n`);
+      // テキストに改行が含まれる場合は、data: を複数行で出力する
+      const data = message
+        .split("\n")
+        .map((line) => `data: ${line}`)
+        .join("\n");
+      writer.write(`${data}\n\n`);
     },
-    () => writer.close(),
+    () => {
+      writer.write(`data: [DONE]\n\n`).then(() => writer.close());
+    },
     (e) => writer.abort(e)
   );
 


### PR DESCRIPTION
## やったこと
- テキストに改行が含まれる場合に複数行の`data: `に変換してレスポンスする仕様に変更
  - 本来のサーバー送信イベントの仕様？を踏襲
  - [Server-Sent イベントによるストリーム更新: 複数行のデータ](https://web.dev/articles/eventsource-basics?hl=ja#multiline_data)
- APIの仕様変更に合わせて
回答のテキストが改行コードで改行されないバグを修正

close #26
close #27 